### PR TITLE
Update react-native version to support only 0.60 and up versions.

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   ],
   "author": "Michael Kuczera",
   "peerDependencies": {
-    "react-native": ">= 0.41.2"
+    "react-native": "^0.60.0"
   },
   "publishConfig": {
     "registry": "https://registry.npmjs.org/"


### PR DESCRIPTION
With the major react-native release (v 0.60), it's recommended to give support for specific versions.