### PR TITLE
Loosen react-native peer dependency version

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   ],
   "author": "Michael Kuczera",
   "peerDependencies": {
-    "react-native": "^0.60.0"
+    "react-native": ">=0.60.0"
   },
   "publishConfig": {
     "registry": "https://registry.npmjs.org/"


### PR DESCRIPTION
When installing this library, yarn currently gives the following warning (I'm using `react-native@~0.63.2`):
```
warning " > react-native-haptic-feedback@1.10.0" has incorrect peer dependency "react-native@^0.60.0"
```
This PR loosens the react-native peer dependency version requirement and should eliminate the warning.