### PR TITLE
fix: Xcode 12 compatibility

### DIFF
--- a/RNReactNativeHapticFeedback.podspec
+++ b/RNReactNativeHapticFeedback.podspec
@@ -17,7 +17,7 @@ Pod::Spec.new do |s|
   s.source_files  = "ios/*.{h,m}"
   s.requires_arc = true
 
-  s.dependency 'React'
+  s.dependency 'React-Core'
 end
 
   


### PR DESCRIPTION
Latest Xcode 12 fails to build while without a module to depend on React-Core directly hence this change is necessary for all native modules on iOS. For more details please check: https://github.com/facebook/react-native/issues/29633#issuecomment-694187116