### PR TITLE
Use mavenCentral instead of jcenter

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -5,7 +5,7 @@ def DEFAULT_MIN_SDK_VERSION                 = 16
 
 buildscript {
     repositories {
-        jcenter()
+        mavenCentral()
         google()
     }
 


### PR DESCRIPTION
As jcenter is being shut down, we should use mavenCentral instead. See https://jfrog.com/blog/into-the-sunset-bintray-jcenter-gocenter-and-chartcenter/