### PR TITLE
fix: Fix duplicate symbol definition build error (ObjC `<` import)

### DIFF
--- a/ios/RNReactNativeHapticFeedback.h
+++ b/ios/RNReactNativeHapticFeedback.h
@@ -1,10 +1,10 @@
 
 #import <Foundation/Foundation.h>
 #import <UIKit/UIKit.h>
-#if __has_include("RCTBridgeModule.h")
-#import "RCTBridgeModule.h"
-#else
+#if __has_include(<React/RCTBridgeModule.h>)
 #import <React/RCTBridgeModule.h>
+#else
+#import "RCTBridgeModule.h"
 #endif
 
 @interface RNReactNativeHapticFeedback : NSObject <RCTBridgeModule>


### PR DESCRIPTION
The `<` import (module maps) fixes duplicate symbol errors on RN 0.67.