### PR TITLE
fix: class declaration

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,5 +1,5 @@
 declare module "react-native-haptic-feedback" {
-  type HapticFeedbackTypes =
+  export type HapticFeedbackTypes =
     | "selection"
     | "impactLight"
     | "impactMedium"
@@ -23,10 +23,14 @@ declare module "react-native-haptic-feedback" {
     | "effectHeavyClick"
     | "effectTick";
 
-  interface HapticOptions {
+  export interface HapticOptions {
     enableVibrateFallback?: boolean;
     ignoreAndroidSystemSettings?: boolean;
   }
 
-  function trigger(type: HapticFeedbackTypes, options?: HapticOptions): void;
+  class ReactNativeHapticFeedback {
+    static trigger(type: HapticFeedbackTypes, options?: HapticOptions): void;
+  }
+
+  export = ReactNativeHapticFeedback;
 }


### PR DESCRIPTION
With the current declaration, `trigger` can be imported from the destructured import

```ts
import { trigger } from 'react-native-haptic-feedback';
```

However, the function does not exist in the source code. This PR fixes this issue and only return `trigger` when used with the class `ReactNativeHapticFeedback.trigger(...)` declaration